### PR TITLE
ObsidianX: native-SegWit-only, no Base58-Types, only bech32

### DIFF
--- a/src/Obsidian-Min.sln.DotSettings
+++ b/src/Obsidian-Min.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coinstake/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Passphrase/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=utxo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=WPKH/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -152,7 +152,8 @@ namespace Obsidian.Networks.ObsidianX
                 .Register<PosFutureDriftRule>()
                 .Register<CheckDifficultyPosRule>()
                 .Register<ObsidianXHeaderVersionRule>()
-                .Register<ObsidianXPreventLegacyRule>()
+                //.Register<ObsidianXPreventLegacyRule>()
+                .Register<ObsidianXRequireNativeSegWitRule>()
                 .Register<ProvenHeaderSizeRule>()
                 .Register<ProvenHeaderCoinstakeRule>();
 

--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -166,7 +166,7 @@ namespace Obsidian.Networks.ObsidianX
                 .Register<PosFutureDriftRule>()
                 .Register<CheckDifficultyPosRule>()
                 .Register<ObsidianXHeaderVersionRule>()
-                //.Register<ObsidianXPreventLegacyRule>()
+                .Register<ObsidianXPreventLegacyRule>()
                 .Register<ProvenHeaderSizeRule>()
                 .Register<ProvenHeaderCoinstakeRule>();
 

--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -152,8 +152,9 @@ namespace Obsidian.Networks.ObsidianX
                 .Register<PosFutureDriftRule>()
                 .Register<CheckDifficultyPosRule>()
                 .Register<ObsidianXHeaderVersionRule>()
-                //.Register<ObsidianXPreventLegacyRule>()
+                .Register<ObsidianXPreventLegacyRule>()
                 .Register<ObsidianXRequireNativeSegWitRule>()
+                .Register<ObsidianXNativeSegWitSpendsOnlyRule>()
                 .Register<ProvenHeaderSizeRule>()
                 .Register<ProvenHeaderCoinstakeRule>();
 

--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -108,21 +108,7 @@ namespace Obsidian.Networks.ObsidianX
             this.Consensus.PosEmptyCoinbase = false;
             this.StandardScriptsRegistry = new ObsidianXStandardScriptsRegistry();
 
-            this.Base58Prefixes = new byte[12][];
-            this.Base58Prefixes[(int)Base58Type.PUBKEY_ADDRESS] = new byte[] { (75) }; // ODN
-            this.Base58Prefixes[(int)Base58Type.SCRIPT_ADDRESS] = new byte[] { (125) };
-            this.Base58Prefixes[(int)Base58Type.SECRET_KEY] = new byte[] { (75 + 128) };  // ODN
-            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_NO_EC] = new byte[] { 0x01, 0x42 };
-            this.Base58Prefixes[(int)Base58Type.ENCRYPTED_SECRET_KEY_EC] = new byte[] { 0x01, 0x43 };
-
-            this.Base58Prefixes[(int)Base58Type.EXT_PUBLIC_KEY] = new byte[] { (0x04), (0x88), (0xC2), (0x1E) }; // matches Obsidian-Qt, StratisX (but not Stratis C# (it's unused though)
-            this.Base58Prefixes[(int)Base58Type.EXT_SECRET_KEY] = new byte[] { (0x04), (0x88), (0xB2), (0xDD) }; // matches Obsidian-Qt, StratisX (but not Stratis C# (it's unused though)
-
-            this.Base58Prefixes[(int)Base58Type.PASSPHRASE_CODE] = new byte[] { 0x2C, 0xE9, 0xB3, 0xE1, 0xFF, 0x39, 0xE2 };
-            this.Base58Prefixes[(int)Base58Type.CONFIRMATION_CODE] = new byte[] { 0x64, 0x3B, 0xF6, 0xA8, 0x9A };
-            this.Base58Prefixes[(int)Base58Type.STEALTH_ADDRESS] = new byte[] { 0x2a };
-            this.Base58Prefixes[(int)Base58Type.ASSET_ID] = new byte[] { 23 };
-            this.Base58Prefixes[(int)Base58Type.COLORED_ADDRESS] = new byte[] { 0x13 };
+            this.Base58Prefixes = new byte[0][];
 
             this.Checkpoints = new Dictionary<int, CheckpointInfo>
             {

--- a/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXNativeSegWitSpendsOnlyRule.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXNativeSegWitSpendsOnlyRule.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Rules;
+
+namespace Obsidian.Networks.ObsidianX.Rules
+{
+    /// <summary>
+    /// Checks if <see cref="ObsidianXMain"/> network's blocks contain legacy coinstake tx or P2PK outputs.
+    /// </summary>
+    public class ObsidianXNativeSegWitSpendsOnlyRule : IntegrityValidationConsensusRule
+    {
+        /// <inheritdoc />
+        /// <exception cref="ConsensusErrors.BadVersion">Thrown if block's version is outdated or otherwise invalid.</exception>
+        public override void Run(RuleContext context)
+        {
+            var block = context.ValidationContext.BlockToValidate;
+
+            for (var i = 0; i < block.Transactions.Count; i++)
+            {
+                if (i == 1) // do not check the Coinstake tx
+                    continue;
+
+                var transaction = block.Transactions[i];
+
+                foreach (var output in transaction.Outputs)
+                {
+                    if (PayToWitTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                        continue; // allowed are P2WPKH and P2WSH
+                    if (TxNullDataTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                        continue; // allowed are also all kinds of valid OP_RETURN pushes
+
+                    this.Logger.LogTrace("(-)[NOT_NATIVE_SEGWIT_OR_DATA]");
+                    new ConsensusError("legacy-tx", "Only P2PKH, P2WSH is allowed outside Coinstake transactions.").Throw();
+                }
+               
+            }
+        }
+    }
+}

--- a/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXRequireNativeSegWitRule.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXRequireNativeSegWitRule.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Rules;
+
+namespace Obsidian.Networks.ObsidianX.Rules
+{
+    /// <summary>
+    /// Checks if <see cref="ObsidianXMain"/> transaction are only native SegWit.
+    /// </summary>
+    public class ObsidianXRequireNativeSegWitRule : IntegrityValidationConsensusRule
+    {
+        public override void Run(RuleContext context)
+        {
+            var block = context.ValidationContext.BlockToValidate;
+
+            foreach (var tx in block.Transactions)
+            {
+                if (tx.IsCoinStake) // Coinstake tx are custom to ObsidianX, skip
+                    continue;
+
+                if (!tx.HasWitness)
+                {
+                    this.Logger.LogTrace("(-)[MISSING_WITNESS]");
+                    new ConsensusError("missing-witness", "Missing Witness in Non-Coinstake Transaction.").Throw();
+                }
+
+                if (!tx.IsCoinBase)
+                {
+                    foreach (var txin in tx.Inputs)
+                    {
+                        // according to BIP-0141, P2WPKH and P2WSH transaction have an empty ScriptSig,
+                        // so let's whitelist these.
+                        if (txin.ScriptSig.Length == 0)
+                            continue;
+                        // P2WPKH nested in BIP16 P2SH, P2WSH nested in BIP16 P2SH, P2SH, P2PKH
+                        // do not have empty ScriptSig, throw!
+                        // This also means that only native SegWit outputs are spendable, because spending other outputs would require a ScriptSig.
+                        this.Logger.LogTrace("(-)[NONEMPTY_ScriptSig]");
+                        new ConsensusError("non-empty-scriptsig", "Only native SegWit (P2WPKH and P2WSH) is allowed.").Throw();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
My Vision for ObsidianX is that the blockchain is 'native-SegWit-only' an only bech32 encodings are supported. While bech32 encodings exist for P2WPH and P2WSH, for other things, e.g. analogies to WIF, they'll need to be invented, and the bech32 spec allows this.

To be clear, I do not propose such stringent rules to be imposed on other blockchains that use the C# fullnode. It's just ObsidianX and it differentiates the coin.

Limiting feature-use in this way allows for extremely optimized code which can replace heuristics that are all so present in NBitcoin.

Explicitly excluded via Consensus should be:
P2PKH
P2PK
P2SH
P2SH-P2WPKH
P2SH-P2WSH
Allowed should be only:
P2WPKH
P2WSH
and the latter with extra op_return outputs.

The safe choice is to block usage right from the Genesis block, since it's easy to bring features back later, but once it's in the chain you can never get rid of it.

The Base58-types defined in Network act as a 'canary', so not supplying the Base58-types-array prevents greater evil that is otherwise difficult to notice. And frankly, they are completely redundant, since bech32-types for P2WPKH and P2WSH are already there.


