### PR TITLE
Rename ObsidianXNativeSegWitSpendsOnlyRule to OutputNotWhitelistedRul…

### DIFF
--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -184,7 +184,7 @@ namespace Obsidian.Networks.ObsidianX
                 // rules to prevent legacy script types and force segwit
                 .Register<ObsidianXPreventLegacyRule>()
                 .Register<ObsidianXRequireNativeSegWitRule>()
-                .Register<ObsidianXNativeSegWitSpendsOnlyRule>()
+                .Register<OutputNotWhitelistedRule>()
 
                 // rules that are inside the method ContextualCheckBlock
                 .Register<TransactionLocktimeActivationRule>()
@@ -221,6 +221,7 @@ namespace Obsidian.Networks.ObsidianX
                 typeof(CheckConflictsMempoolRule),
                 typeof(CheckCoinViewMempoolRule),
                 typeof(CreateMempoolEntryMempoolRule),
+                typeof(ObsidianXOutputNotWhitelistedMempoolRule),
                 typeof(CheckSigOpsMempoolRule),
                 typeof(CheckFeeMempoolRule),
                 typeof(CheckRateLimitMempoolRule),

--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -184,7 +184,7 @@ namespace Obsidian.Networks.ObsidianX
                 // rules to prevent legacy script types and force segwit
                 .Register<ObsidianXPreventLegacyRule>()
                 .Register<ObsidianXRequireNativeSegWitRule>()
-                .Register<OutputNotWhitelistedRule>()
+                .Register<ObsidianXOutputNotWhitelistedRule>()
 
                 // rules that are inside the method ContextualCheckBlock
                 .Register<TransactionLocktimeActivationRule>()

--- a/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXConsensusErrors.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXConsensusErrors.cs
@@ -1,0 +1,9 @@
+﻿using Stratis.Bitcoin.Consensus;
+
+namespace Obsidian.Networks.ObsidianX.Rules
+{
+    public static class ObsidianXConsensusErrors
+    {
+        public static ConsensusError OutputNotWhitelisted => new ConsensusError("tx-output-not-whitelisted", "Only P2WPKH, P2WSH, OP_RETURN and CS_SETUP is allowed outside protocol transactions.");
+    }
+}

--- a/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXOutputNotWhitelistedMempoolRule.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXOutputNotWhitelistedMempoolRule.cs
@@ -8,7 +8,7 @@ using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
 namespace Obsidian.Networks.ObsidianX.Rules
 {
     /// <summary>
-    /// Checks if transactions match the white-listing criteria. This rule and <see cref="OutputNotWhitelistedRule"/> must correspond.
+    /// Checks if transactions match the white-listing criteria. This rule and <see cref="ObsidianXOutputNotWhitelistedRule"/> must correspond.
     /// </summary>
     public class ObsidianXOutputNotWhitelistedMempoolRule : MempoolRule
     {

--- a/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXOutputNotWhitelistedMempoolRule.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXOutputNotWhitelistedMempoolRule.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Extensions.Logging;
+using NBitcoin;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.ColdStaking;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.MemoryPool.Interfaces;
+
+namespace Obsidian.Networks.ObsidianX.Rules
+{
+    /// <summary>
+    /// Checks if transactions match the white-listing criteria. This rule and <see cref="OutputNotWhitelistedRule"/> must correspond.
+    /// </summary>
+    public class ObsidianXOutputNotWhitelistedMempoolRule : MempoolRule
+    {
+        readonly IConsensusRuleEngine consensusRules;
+
+        public ObsidianXOutputNotWhitelistedMempoolRule(Network network,
+            ITxMempool mempool,
+            MempoolSettings mempoolSettings,
+            ChainIndexer chainIndexer,
+            IConsensusRuleEngine consensusRules,
+            ILoggerFactory loggerFactory) : base(network, mempool, mempoolSettings, chainIndexer, loggerFactory)
+        {
+            this.consensusRules = consensusRules;
+        }
+
+        public override void CheckTransaction(MempoolValidationContext context)
+        {
+            if (context.Transaction.IsCoinStake || (context.Transaction.IsCoinBase && context.Transaction.Outputs[0].IsEmpty)) // also check the coinbase tx in PoW blocks
+                return;
+
+            foreach (var output in context.Transaction.Outputs)
+            {
+
+                if (PayToWitTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                    continue; // allowed are P2WPKH and P2WSH
+                if (TxNullDataTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                    continue; // allowed are also all kinds of valid OP_RETURN pushes
+                if (ColdStakingScriptTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                    continue; // allowed cold staking setup trx
+
+                this.logger.LogTrace($"(-)[FAIL_{nameof(ObsidianXOutputNotWhitelistedMempoolRule)}]".ToUpperInvariant());
+                context.State.Fail(new MempoolError(ObsidianXConsensusErrors.OutputNotWhitelisted)).Throw();
+            }
+        }
+    }
+}

--- a/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXOutputNotWhitelistedRule.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/ObsidianXOutputNotWhitelistedRule.cs
@@ -9,7 +9,7 @@ namespace Obsidian.Networks.ObsidianX.Rules
     /// <summary>
     /// Checks if transactions match the white-listing criteria. This rule and <see cref="ObsidianXOutputNotWhitelistedMempoolRule"/> must correspond.
     /// </summary>
-    public class OutputNotWhitelistedRule : PartialValidationConsensusRule
+    public class ObsidianXOutputNotWhitelistedRule : PartialValidationConsensusRule
     {
         public override Task RunAsync(RuleContext context)
         {
@@ -34,7 +34,7 @@ namespace Obsidian.Networks.ObsidianX.Rules
                     if (ColdStakingScriptTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
                         continue; // allowed cold staking setup trx
 
-                    this.Logger.LogTrace($"(-)[FAIL_{nameof(OutputNotWhitelistedRule)}]".ToUpperInvariant());
+                    this.Logger.LogTrace($"(-)[FAIL_{nameof(ObsidianXOutputNotWhitelistedRule)}]".ToUpperInvariant());
                     ObsidianXConsensusErrors.OutputNotWhitelisted.Throw();
                 }
             }

--- a/src/Obsidian.Networks.ObsidianX/Rules/OutputNotWhitelistedRule.cs
+++ b/src/Obsidian.Networks.ObsidianX/Rules/OutputNotWhitelistedRule.cs
@@ -1,19 +1,16 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.ColdStaking;
 
 namespace Obsidian.Networks.ObsidianX.Rules
 {
     /// <summary>
-    /// Checks if <see cref="ObsidianXMain"/> network's blocks confirm to the 'native-SegWit-only' white-listing criteria.
+    /// Checks if transactions match the white-listing criteria. This rule and <see cref="ObsidianXOutputNotWhitelistedMempoolRule"/> must correspond.
     /// </summary>
-    public class ObsidianXNativeSegWitSpendsOnlyRule : PartialValidationConsensusRule
+    public class OutputNotWhitelistedRule : PartialValidationConsensusRule
     {
-        /// <inheritdoc />
-        /// <exception cref="ConsensusErrorException">Thrown if a block's transactions confirm to the 'native-SegWit-only' white-listing criteria.</exception>
         public override Task RunAsync(RuleContext context)
         {
             var block = context.ValidationContext.BlockToValidate;
@@ -37,8 +34,8 @@ namespace Obsidian.Networks.ObsidianX.Rules
                     if (ColdStakingScriptTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
                         continue; // allowed cold staking setup trx
 
-                    this.Logger.LogTrace("(-)[NOT_NATIVE_SEGWIT_OR_DATA]");
-                    new ConsensusError("legacy-tx", "Only P2WPKH, P2WSH is allowed outside Coinstake transactions.").Throw();
+                    this.Logger.LogTrace($"(-)[FAIL_{nameof(OutputNotWhitelistedRule)}]".ToUpperInvariant());
+                    ObsidianXConsensusErrors.OutputNotWhitelisted.Throw();
                 }
             }
 


### PR DESCRIPTION
Rename ObsidianXNativeSegWitSpendsOnlyRule to OutputNotWhitelistedRule. Introduce a corresponding MempoolRule. Make it cleaner.