### PR TITLE
Remove the rule ObsidianXRequireNativeSegWitRule

### DIFF
--- a/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
+++ b/src/Obsidian.Networks.ObsidianX/ObsidianXMain.cs
@@ -183,7 +183,7 @@ namespace Obsidian.Networks.ObsidianX
 
                 // rules to prevent legacy script types and force segwit
                 .Register<ObsidianXPreventLegacyRule>()
-                .Register<ObsidianXRequireNativeSegWitRule>()
+                //.Register<ObsidianXRequireNativeSegWitRule>()
                 .Register<ObsidianXOutputNotWhitelistedRule>()
 
                 // rules that are inside the method ContextualCheckBlock


### PR DESCRIPTION
The rule ObsidianXRequireNativeSegWitRule is not a good idea as it limits script sigs while the script limitation should be per outputs not input.

This PR will remove that rule all together.